### PR TITLE
Search all projects for stories to deliver by default

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- The "--project" CLI argument is now optional. By default all projects are
+  searched for stories which can be delivered.
+
+
 1.000001 2017-04-26
 
 - Add IPC::System::Simple as a prereq for the benefit of autodie. Reported by


### PR DESCRIPTION
I know that there was a suggestion to look up stories across projects in parallel, but that seems like a premature optimization for a first pass at this change. For just a few projects (say 2-4) I don't think the speed difference would be very noticeable.