### PR TITLE
Include required parameter in object creation

### DIFF
--- a/lib/App/GHPT/WorkSubmitter.pm
+++ b/lib/App/GHPT/WorkSubmitter.pm
@@ -131,6 +131,7 @@ sub run ($self) {
 sub _append_question_answers ( $self, $text ) {
     my $qa_markdown = App::GHPT::WorkSubmitter::AskPullRequestQuestions->new(
         merge_to_branch_name => 'origin/' . $self->base,
+        question_namespaces  => $self->_question_namespaces,
     )->ask_questions;
     return $text unless defined $qa_markdown and length $qa_markdown;
     return join "\n\n",


### PR DESCRIPTION
The instantiation of an App::GHPT::WorkSubmitter::AskPullRequestQuestions object is missing a required parameter `question_namespaces`. I've added it.