### PR TITLE
Clear screen for better readable interactive menus

### DIFF
--- a/lib/App/GHPT/WorkSubmitter.pm
+++ b/lib/App/GHPT/WorkSubmitter.pm
@@ -311,7 +311,7 @@ sub _filter_chores_and_maybe_warn_user ( $self, $stories ) {
 }
 
 sub _confirm_story ( $self, $text ) {
-    my $result = $self->_choose( [ 'Accept', 'Edit' ], { prompt => $text } );
+    my $result = $self->_choose( [ 'Accept', 'Edit' ], { prompt => $text, clear_screen => $ENV{'SUBMIT_WORK_CLEAR'} // 0 } );
     return $text if $result eq 'Accept';
     my $fh = solicit($text);
     return do { local $/ = undef; <$fh> };

--- a/lib/App/GHPT/WorkSubmitter/Role/Question.pm
+++ b/lib/App/GHPT/WorkSubmitter/Role/Question.pm
@@ -21,7 +21,7 @@ sub ask_question ( $self, $question, @responses ) {
             @responses,
             'Launch Editor'
         ],
-        { prompt => $question }
+        { prompt => $question, clear_screen => $ENV{'SUBMIT_WORK_CLEAR'} // 0 }
     ) or exit;    # user hit 'q' or ctrl-d to stop
 
     return $self->format_qa_markdown( $question, $choice )


### PR DESCRIPTION
When running this in OSX - I have issues with the menu prompts overwriting on existing text in the console, making it difficult to read and respond to prompts.

Adding this line fixed all rendering issues for me.

Note - this behavior was seen on OSX using normal /bin/bash (version 3.2.57)