### PR TITLE
perlimports

### DIFF
--- a/bin/gh-pt.pl
+++ b/bin/gh-pt.pl
@@ -4,10 +4,10 @@ use App::GHPT::Wrapper::Ourperl;
 
 our $VERSION = '2.000000';
 
-use FindBin qw($Bin);
+use FindBin qw( $Bin );
 use lib "$Bin/../../lib", "$Bin/../../../lib";
 
-use App::GHPT::WorkSubmitter;
+use App::GHPT::WorkSubmitter ();
 
 exit App::GHPT::WorkSubmitter->new_with_options->run;
 

--- a/lib/App/GHPT/WorkSubmitter.pm
+++ b/lib/App/GHPT/WorkSubmitter.pm
@@ -5,16 +5,16 @@ use App::GHPT::Wrapper::OurMoose;
 our $VERSION = '2.000000';
 
 use App::GHPT::Types qw( ArrayRef Bool PositiveInt Str );
-use App::GHPT::WorkSubmitter::AskPullRequestQuestions;
-use File::HomeDir       ();
-use IPC::Run3           qw( run3 );
-use Lingua::EN::Inflect qw( PL PL_V );
-use List::AllUtils      qw( part );
-use Pithub              ();
-use Term::CallEditor    qw( solicit );
-use Term::Choose        qw( choose );
-use WebService::PivotalTracker 0.10;
-use YAML::PP;
+use App::GHPT::WorkSubmitter::AskPullRequestQuestions ();
+use File::HomeDir                                     ();
+use IPC::Run3                                         qw( run3 );
+use Lingua::EN::Inflect                               qw( PL PL_V );
+use List::AllUtils                                    qw( part );
+use Pithub                                            ();
+use Term::CallEditor                                  qw( solicit );
+use Term::Choose                                      qw( choose );
+use WebService::PivotalTracker 0.10                   ();
+use YAML::PP                                          ();
 
 with 'MooseX::Getopt::Dashes';
 

--- a/lib/App/GHPT/WorkSubmitter/AskPullRequestQuestions.pm
+++ b/lib/App/GHPT/WorkSubmitter/AskPullRequestQuestions.pm
@@ -4,9 +4,9 @@ use App::GHPT::Wrapper::OurMoose;
 
 our $VERSION = '2.000000';
 
-use App::GHPT::Types qw( ArrayRef Str );
-use Module::Pluggable::Object;
-use App::GHPT::WorkSubmitter::ChangedFilesFactory;
+use App::GHPT::Types                              qw( ArrayRef Str );
+use Module::Pluggable::Object                     ();
+use App::GHPT::WorkSubmitter::ChangedFilesFactory ();
 
 has merge_to_branch_name => (
     is       => 'ro',

--- a/lib/App/GHPT/WorkSubmitter/ChangedFilesFactory.pm
+++ b/lib/App/GHPT/WorkSubmitter/ChangedFilesFactory.pm
@@ -11,7 +11,7 @@ use App::GHPT::WorkSubmitter::ChangedFiles;
 has changed_files_class => (
     is      => 'ro',
     isa     => Str,
-    default => 'App::GHPT::WorkSubmitter::ChangedFiles',
+    default => App::GHPT::WorkSubmitter::ChangedFiles::,
 );
 
 has merge_to_branch_name => (

--- a/lib/App/GHPT/Wrapper/OurMooseX/Role/Parameterized.pm
+++ b/lib/App/GHPT/Wrapper/OurMooseX/Role/Parameterized.pm
@@ -6,7 +6,6 @@ our $VERSION = '2.000000';
 
 use Import::Into;
 use Moose::Exporter;
-use Moose::Util                    qw( find_meta );
 use MooseX::Role::Parameterized    ();
 use MooseX::SemiAffordanceAccessor ();
 use

--- a/t/lib/App/GHPT/Wrapper/OurTest/Class/Moose.pm
+++ b/t/lib/App/GHPT/Wrapper/OurTest/Class/Moose.pm
@@ -8,8 +8,6 @@ use App::GHPT::Wrapper::Ourperl;
 
 use Import::Into;
 use Test::Class::Moose 0.82 ();
-use Test::Class::Moose::AttributeRegistry ();
-use Test::More;
 use namespace::autoclean ();
 
 sub import {

--- a/t/lib/TestFor/App/GHPT/WorkSubmitter.pm
+++ b/t/lib/TestFor/App/GHPT/WorkSubmitter.pm
@@ -5,9 +5,7 @@ use App::GHPT::Wrapper::OurTest::Class::Moose;
 use Hash::Objectify       qw( objectify );
 use Helper::MockPTAPI     ();
 use Helper::WorkSubmitter ();
-use Test::Differences;
-use Test::More;
-use Test::Output qw( stdout_is stdout_like );
+use Test::Output          qw( stdout_is stdout_like );
 
 # This test suite relies upon mock PT data returned by Helper::MockPTAPI
 # and mock Term::Choose::choose() data returned by Helper::WorkSubmitter.

--- a/t/lib/TestFor/App/GHPT/WorkSubmitter/ChangedFiles.pm
+++ b/t/lib/TestFor/App/GHPT/WorkSubmitter/ChangedFiles.pm
@@ -1,7 +1,7 @@
 package TestFor::App::GHPT::WorkSubmitter::ChangedFiles;
 
 use App::GHPT::Wrapper::OurTest::Class::Moose;
-use App::GHPT::WorkSubmitter::ChangedFilesFactory;
+use App::GHPT::WorkSubmitter::ChangedFilesFactory ();
 
 ########################################################################
 

--- a/t/lib/TestRole/WithGitRepo.pm
+++ b/t/lib/TestRole/WithGitRepo.pm
@@ -6,7 +6,6 @@ use File::pushd qw( pushd );
 use File::Temp  qw( tempdir );
 use File::Which qw( which );
 use IPC::Run3   qw( run3 );
-use Try::Tiny;
 
 has _tempdir => (
     is      => 'ro',

--- a/t/run-test-class-moose.t
+++ b/t/run-test-class-moose.t
@@ -1,6 +1,6 @@
 use App::GHPT::Wrapper::Ourperl;
 
-use Test::Class::Moose::CLI;
+use Test::Class::Moose::CLI ();
 
 # We set this for git
 local $ENV{EMAIL} = 'test@example.com';


### PR DESCRIPTION
This PR will drop the following direct dependencies:

```diff
diff --git a/cpanfile b/cpanfile
index e65c664..6b38987 100644
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-# This file is generated by Dist::Zilla::Plugin::CPANFile v6.024
+# This file is generated by Dist::Zilla::Plugin::CPANFile v6.025
 # Do not edit this file directly. To change prereqs, edit the `dist.ini` file.

 requires "File::HomeDir" => "0";
@@ -13,7 +13,6 @@ requires "Module::Pluggable::Object" => "0";
 requires "Moose" => "0";
 requires "Moose::Exporter" => "0";
 requires "Moose::Role" => "0";
-requires "Moose::Util" => "0";
 requires "MooseX::Getopt::Dashes" => "0";
 requires "MooseX::Role::Parameterized" => "0";
 requires "MooseX::Role::Parameterized::Meta::Trait::Parameterizable" => "0";
@@ -50,12 +49,9 @@ on 'test' => sub {
   requires "File::pushd" => "0";
   requires "Hash::Objectify" => "0";
   requires "Test::Class::Moose" => "0.82";
-  requires "Test::Class::Moose::AttributeRegistry" => "0";
   requires "Test::Class::Moose::CLI" => "0";
-  requires "Test::Differences" => "0";
   requires "Test::More" => "0.96";
   requires "Test::Output" => "0";
-  requires "Try::Tiny" => "0";
 };
```

`Test::Differences` will still be in the stack as it gets pulled in via `Test::Most` which is imported via `Test::Class::Moose`.