### PR TITLE
Prefer GH_ENTERPRISE_TOKEN and GITHUB_ENTERPRISE_TOKEN if not a public GitHub host

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
+---
 name: Tests
 
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '5 15 * * SUN'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           name: build_dir
           path: .
 
-      - run: cpm install -g
+      - run: cpm install -g --with-recommends
 
       - name: Install latest perltidy
         run: cpm install -g Perl::Tidy
@@ -76,4 +76,43 @@ jobs:
         env:
           AUTHOR_TESTING: 1
           RELEASE_TESTING: 1
+        run: perl Makefile.PL && make test
+
+  minimal-test-job:
+    needs: build-job
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+        perl:
+          - "5.36"
+
+    name: Minimal Test Perl ${{ matrix.perl }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: build_dir
+          path: .
+
+      - run: cpm install -g
+
+      - name: Set default Git config
+        run: |
+          git config --global init.defaultBranch main
+          git config --global user.email "test@example.com"
+          git config --global user.name "Test"
+
+      - name: Run Tests
+        env:
+          AUTHOR_TESTING: 0
+          RELEASE_TESTING: 0
         run: perl Makefile.PL && make test

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+- Prefer GH_ENTERPRISE_TOKEN and GITHUB_ENTERPRISE_TOKEN if not a public GitHub
+  host (GH#36) (Olaf Alders)
+
 2.000000 2022-06-23
 
 - The "hub" CLI tool is no longer used for created pull requests. The GitHub

--- a/dist.ini
+++ b/dist.ini
@@ -20,3 +20,10 @@ stopwords = OAuth
 stopwords = PRs
 stopwords = Str
 -remove = Test::Synopsis
+
+[Prereqs / TestRequires]
+Test::Needs = 0
+
+[Prereqs / TestRecommends]
+File::pushd = 0
+Test::Git = 0

--- a/lib/App/GHPT/WorkSubmitter.pm
+++ b/lib/App/GHPT/WorkSubmitter.pm
@@ -4,12 +4,12 @@ use App::GHPT::Wrapper::OurMoose;
 
 our $VERSION = '2.000000';
 
-use App::GHPT::Types qw( ArrayRef Bool PositiveInt Str );
+use App::GHPT::Types qw( ArrayRef Bool HashRef PositiveInt Str );
 use App::GHPT::WorkSubmitter::AskPullRequestQuestions ();
 use File::HomeDir                                     ();
 use IPC::Run3                                         qw( run3 );
 use Lingua::EN::Inflect                               qw( PL PL_V );
-use List::AllUtils                                    qw( part );
+use List::AllUtils                                    qw( first part );
 use Pithub                                            ();
 use Term::CallEditor                                  qw( solicit );
 use Term::Choose                                      qw( choose );
@@ -23,6 +23,22 @@ has create_story => (
     isa           => Bool,
     documentation =>
         'If true, will create a new story instead of finding an existing one.',
+);
+
+has _env_keys => (
+    traits  => ['Array'],
+    is      => 'ro',
+    isa     => ArrayRef,
+    lazy    => 1,
+    builder => '_build_env_keys',
+    handles => { _all_env_keys => 'elements', _get_env_key => 'get', },
+);
+
+has _is_ghe => (
+    is      => 'ro',
+    isa     => Bool,
+    lazy    => 1,
+    default => sub ($self) { lc( $self->_host ) eq 'github.com' ? 0 : 1; },
 );
 
 has project => (
@@ -161,6 +177,22 @@ has _git_config => (
     handles => { _config_val => 'get' },
 );
 
+has _git_remote => (
+    traits  => ['Hash'],
+    is      => 'ro',
+    isa     => HashRef,
+    lazy    => 1,
+    builder => '_build_git_remote',
+    handles => { _remote_val => 'get' },
+);
+
+has _host => (
+    is      => 'ro',
+    isa     => Str,
+    lazy    => 1,
+    default => sub ($self) { $self->_remote_val('host') },
+);
+
 has _project_ids => (
     is      => 'ro',
     isa     => ArrayRef [PositiveInt],
@@ -168,21 +200,27 @@ has _project_ids => (
     builder => '_build_project_ids',
 );
 
-sub _build_github_api ($self) {
-    my ( $host, $user, $repo ) = $self->_github_info;
-    my $hub_config = $self->_hub_config->{$host}[0] // {};
+has _pithub_args => (
+    is      => 'ro',
+    isa     => HashRef,
+    lazy    => 1,
+    builder => '_build_pithub_args',
+);
 
-    my $protocol = $self->_github_protocol($hub_config);
+sub _build_pithub_args ($self) {
+    my $hub_config = $self->_hub_config->{ $self->_host }[0] // {};
+    my $protocol   = $self->_github_protocol($hub_config);
 
-    return Pithub->new(
-        user  => $user,
-        repo  => $repo,
+    return {
+        user  => $self->_remote_val('user'),
+        repo  => $self->_remote_val('repo'),
         head  => $self->_git_current_branch,
         token => $self->_github_token($hub_config),
         (
-            $host eq 'github.com' ? () : (
-                api_uri => "$protocol://$host/api/v3/",
-            )
+            $self->_is_ghe
+            ? ( api_uri =>
+                    sprintf( '%s://%s/api/v3/', $protocol, $self->_host ) )
+            : ()
         ),
         (
             $self->_has_github_ua
@@ -191,7 +229,11 @@ sub _build_github_api ($self) {
                 )
             : (),
         ),
-    );
+    };
+}
+
+sub _build_github_api ($self) {
+    return Pithub->new( $self->_pithub_args );
 }
 
 sub _github_protocol ( $self, $hub_config ) {
@@ -205,11 +247,36 @@ sub _github_protocol ( $self, $hub_config ) {
 sub _github_token ( $self, $hub_config ) {
     return $self->github_token if $self->_has_github_token;
 
-    my $env_key = 'GITHUB_TOKEN';
-    my $key     = 'submit-work.github.token';
-    return $ENV{$env_key} // $self->_config_val($key)
+    my $key = 'submit-work.github.token';
+    return $self->_token_from_env // $self->_config_val($key)
         // $hub_config->{oauth_token}
-        // $self->_require_env_or_git_config( $env_key, $key );
+        // $self->_require_env_or_git_config( $self->_get_env_key(0), $key );
+}
+
+# Use order of precedence for env vars as defined at
+# https://cli.github.com/manual/gh_help_environment:w
+#
+# Add GITHUB_TOKEN to enterprise list for backwards compatibility.
+sub _build_env_keys ($self) {
+    return $self->_is_ghe
+        ? [
+        qw(
+            GH_ENTERPRISE_TOKEN
+            GITHUB_ENTERPRISE_TOKEN
+            GITHUB_TOKEN
+        )
+        ]
+        : [
+        qw(
+            GH_TOKEN
+            GITHUB_TOKEN
+        )
+        ];
+}
+
+sub _token_from_env ($self) {
+    my $key = first { $ENV{$_} } $self->_all_env_keys;
+    return $key ? $ENV{$key} : undef;
 }
 
 sub _build_pivotaltracker_token ($self) {
@@ -452,19 +519,19 @@ sub _format_github_error ($res) {
     return $res->raw_content;
 }
 
-sub _github_info ($self) {
+sub _build_git_remote ($self) {
     my $git_url = $self->_git_config->{'remote.origin.url'} // q{};
 
     if ( my ( $host, $user, $repo )
         = $git_url =~ m{^git@([^:]+):([^/]+)/([^/]+?)(?:\.git)?$} ) {
-        return ( $host, $user, $repo );
+        return { host => $host, user => $user, repo => $repo };
     }
 
     my $uri = URI->new($git_url);
     if ( $uri->can('host') && $uri->can('path') ) {
         if ( my ( $user, $repo )
             = $uri->path =~ m{/([^/]+)/([^/]+?)(?:\.git)?$} ) {
-            return ( $uri->host, $user, $repo );
+            return { host => $uri->host, user => $user, repo => $repo };
         }
     }
 
@@ -531,5 +598,4 @@ sub _require_env_or_git_config ( $self, $env, $key ) {
 }
 
 __PACKAGE__->meta->make_immutable;
-
 1;

--- a/lib/App/GHPT/WorkSubmitter/ChangedFilesFactory.pm
+++ b/lib/App/GHPT/WorkSubmitter/ChangedFilesFactory.pm
@@ -4,9 +4,9 @@ use App::GHPT::Wrapper::OurMoose;
 
 our $VERSION = '2.000000';
 
-use IPC::Run3        qw( run3 );
-use App::GHPT::Types qw( ArrayRef HashRef Str );
-use App::GHPT::WorkSubmitter::ChangedFiles;
+use IPC::Run3                              qw( run3 );
+use App::GHPT::Types                       qw( ArrayRef HashRef Str );
+use App::GHPT::WorkSubmitter::ChangedFiles ();
 
 has changed_files_class => (
     is      => 'ro',

--- a/t/enterprise.t
+++ b/t/enterprise.t
@@ -1,0 +1,73 @@
+#!perl
+use strict;
+use warnings;
+
+# use lib 't/lib';
+
+use App::GHPT::WorkSubmitter ();
+use Test::More import => [qw( done_testing is ok )];
+use Test::Differences qw( eq_or_diff );
+use Test::Needs       qw( File::pushd Test::Git );
+
+Test::Git->import('test_repository');
+my $repo = test_repository();
+
+$repo->run(
+    'remote', 'add', 'origin',
+    'git@github.example.com:del/trotter.git'
+);
+
+File::pushd->import('pushd');
+my $dir = pushd( $repo->git_dir );
+
+local $ENV{GITHUB_TOKEN}            = undef;
+local $ENV{GH_TOKEN}                = undef;
+local $ENV{GH_ENTERPRISE_TOKEN}     = undef;
+local $ENV{GITHUB_ENTERPRISE_TOKEN} = undef;
+
+{
+    my $secret = 'ghenterprisesecret';
+    local $ENV{GH_ENTERPRISE_TOKEN} = $secret;
+    my $ws = App::GHPT::WorkSubmitter->new;
+    is( $ws->_token_from_env, $secret,              'token' );
+    is( $ws->_host,           'github.example.com', 'host found via remote' );
+    ok( $ws->_is_ghe, 'is a ghe host' );
+
+    eq_or_diff(
+        $ws->_pithub_args,
+        {
+            api_uri => 'https://github.example.com/api/v3/',
+            head    => 'HEAD',
+            repo    => 'trotter',
+            token   => $secret,
+            user    => 'del',
+        },
+        'Pithub args'
+    );
+}
+
+{
+    my $secret = 'githubenterprisesecret';
+    local $ENV{GITHUB_ENTERPRISE_TOKEN} = $secret;
+    my $ws = App::GHPT::WorkSubmitter->new;
+    is( $ws->_token_from_env, $secret, 'token' );
+}
+
+{
+    my $secret = 'githubsecret';
+    local $ENV{GITHUB_TOKEN} = $secret;
+    my $ws = App::GHPT::WorkSubmitter->new;
+    is( $ws->_token_from_env, $secret, 'token' );
+}
+
+{
+    my $secret = 'ghsecret';
+    local $ENV{GH_TOKEN} = $secret;
+    my $ws = App::GHPT::WorkSubmitter->new;
+    is(
+        $ws->_token_from_env, undef,
+        'no token from GH_TOKEN when URL is GHE'
+    );
+}
+
+done_testing();


### PR DESCRIPTION
- Prefer GH_ENTERPRISE_TOKEN and GITHUB_ENTERPRISE_TOKEN if not a public GitHub host

The enterprise tests are not using `Test::Class::Moose` because it seems that a skip generated by `Test::Needs` causes everything in the suite to be skipped. I didn't spend a lot of time on it and I'm not sure there was a lot to be gained via `Test::Class::Moose` for this simple test.

These results are from running the test suite as it is in this PR with an additional test class which also contains the enterprise tests.

```
prove -lvr t
t/enterprise.t ............
ok 1 - token
ok 2 - host found via remote
ok 3 - is a ghe host
ok 4 - Pithub args
ok 5 - token
ok 6 - token
ok 7 - no token from GH_TOKEN when URL is GHE
1..7
ok
t/run-test-class-moose.t ..
1..0 # SKIP Need xFile::pushd
skipped: Need xFile::pushd
All tests successful.
Files=2, Tests=7,  7 wallclock secs ( 0.03 usr  0.01 sys +  1.87 cusr  0.63 csys =  2.54 CPU)
Result: PASS
```